### PR TITLE
Try to get book to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: R
 sudo: false
 cache: packages
 
+branches: 
+  except: 
+  - develop
+
 before_install: 
   - sudo apt-get install libudunits2-dev
   - sudo apt-get install libgdal-dev


### PR DESCRIPTION
Most recent commits aren't included, e.g., vignette intro. Travis is using the default branch to build the website, which is set in GitHub currently as develop, but we want it to build master. I'm not sure if there's a way to separate these two things, so I'm trying to get Travis to not build develop at all. 

<img width="1172" alt="Screen Shot 2019-06-11 at 10 59 47 AM" src="https://user-images.githubusercontent.com/6686508/59295273-1d59ea80-8c38-11e9-9d31-4b32af4038ea.png">

This must be a common workflow, to commit and push to the develop branch but then only build once develop is merged into master. Maybe my Googling is off? 