### PR TITLE
Change bookdown output directory to default

### DIFF
--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -1,6 +1,5 @@
 book_filename: "terraref-tutorials"
 delete_merged_file: true
-output_dir: "docs"
 language:
   ui:
     chapter_name: "Chapter "


### PR DESCRIPTION
This was left out of #165, so it caused a deployment error for Travis because it was trying to use the recently deleted docs folder. The default for `output_dir` is `_book`. 